### PR TITLE
feat: match redirects by specificity instead of database insertion order

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,16 @@
+## From v2 to v3
+
+Redirects are now matched by specificity rather than database insertion order:
+
+1. Exact routes (no parameters) match first
+2. Routes with fewer parameters match before more generic ones
+3. Routes with more literal segments take priority when parameter counts are equal
+4. Greedy wildcard routes (`.*`) match last
+
+If you were relying on database insertion order to resolve conflicts between overlapping redirects, you may need to review your configuration.
+
+If you need custom ordering, you can extend `CheckForRedirects` and override the `compareRedirects` method.
+
 ## From v1 to v2
 This package now has improved support for caching.
 - A new `ClearRedirectsCacheCommand` has been added to clear the cache (`php artisan redirects:clear-cache`).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,7 +9,7 @@ Redirects are now matched by specificity rather than database insertion order:
 
 If you were relying on database insertion order to resolve conflicts between overlapping redirects, you may need to review your configuration.
 
-If you need custom ordering, you can extend `CheckForRedirects` and override the `compareRedirects` method.
+If you need custom ordering, you can extend `CheckForRedirects` and override the `sortRedirects` method.
 
 ## From v1 to v2
 This package now has improved support for caching.

--- a/src/Contracts/RedirectorContract.php
+++ b/src/Contracts/RedirectorContract.php
@@ -6,5 +6,6 @@ use Illuminate\Http\Request;
 
 interface RedirectorContract
 {
+    /** @return \Esign\Redirects\DataTransferObjects\RedirectDTO[] */
     public function getRedirectsForRequest(Request $request): array;
 }

--- a/src/Http/Middleware/CheckForRedirects.php
+++ b/src/Http/Middleware/CheckForRedirects.php
@@ -34,9 +34,7 @@ class CheckForRedirects
         $redirects = app(RedirectorContract::class)->getRedirectsForRequest($request);
         $router = new Router(app(Dispatcher::class), app(Container::class));
 
-        usort($redirects, fn ($a, $b) => $this->compareRedirects($a, $b));
-
-        foreach ($redirects as $redirectDTO) {
+        foreach ($this->sortRedirects($redirects) as $redirectDTO) {
             $router->redirect(
                 $redirectDTO->oldUrl,
                 $redirectDTO->newUrl,
@@ -47,28 +45,27 @@ class CheckForRedirects
         return $router->dispatch($request);
     }
 
-    protected function compareRedirects(RedirectDTO $a, RedirectDTO $b): int
+    /** @param RedirectDTO[] $redirects */
+    protected function sortRedirects(array $redirects): array
     {
-        // Greedy wildcards (constraints containing .*) are the least specific — always last
-        $aGreedy = in_array('.*', $a->constraints) ? 1 : 0;
-        $bGreedy = in_array('.*', $b->constraints) ? 1 : 0;
+        // Pre-compute sort keys once per redirect (n) rather than on every
+        // comparison (n log n) to keep the sort efficient for large datasets.
+        $keys = array_map(fn (RedirectDTO $dto) => [
+            in_array('.*', $dto->constraints) ? 1 : 0,  // greedy wildcards last
+            substr_count($dto->oldUrl, '{'),              // fewer params first
+            -count(array_filter(                          // more literal segments first
+                explode('/', $dto->oldUrl),
+                fn (string $segment) => ! str_contains($segment, '{'),
+            )),
+        ], $redirects);
 
-        if ($aGreedy !== $bGreedy) {
-            return $aGreedy <=> $bGreedy;
-        }
+        array_multisort(
+            array_column($keys, 0), SORT_ASC,
+            array_column($keys, 1), SORT_ASC,
+            array_column($keys, 2), SORT_ASC,
+            $redirects,
+        );
 
-        // Fewer parameters = more specific = first
-        $aParams = substr_count($a->oldUrl, '{');
-        $bParams = substr_count($b->oldUrl, '{');
-
-        if ($aParams !== $bParams) {
-            return $aParams <=> $bParams;
-        }
-
-        // Tie-break: more literal segments = more specific = first
-        $aLiterals = count(array_filter(explode('/', $a->oldUrl), fn ($s) => ! str_contains($s, '{')));
-        $bLiterals = count(array_filter(explode('/', $b->oldUrl), fn ($s) => ! str_contains($s, '{')));
-
-        return $bLiterals <=> $aLiterals;
+        return $redirects;
     }
 }

--- a/src/Http/Middleware/CheckForRedirects.php
+++ b/src/Http/Middleware/CheckForRedirects.php
@@ -48,12 +48,15 @@ class CheckForRedirects
     /** @param RedirectDTO[] $redirects */
     protected function sortRedirects(array $redirects): array
     {
-        // Pre-compute sort keys once per redirect (n) rather than on every
-        // comparison (n log n) to keep the sort efficient for large datasets.
+        // Pre-compute sort keys per redirect so string operations are not repeated
+        // on every comparison, keeping the sort efficient for large redirect sets.
         $keys = array_map(fn (RedirectDTO $dto) => [
-            in_array('.*', $dto->constraints) ? 1 : 0,  // greedy wildcards last
-            substr_count($dto->oldUrl, '{'),              // fewer params first
-            -count(array_filter(                          // more literal segments first
+            // Greedy wildcards (.*) are least specific — always last
+            in_array('.*', $dto->constraints) ? 1 : 0,
+            // Fewer parameters = more specific = first
+            substr_count($dto->oldUrl, '{'),
+            // More literal segments = more specific = first
+            -count(array_filter(
                 explode('/', $dto->oldUrl),
                 fn (string $segment) => ! str_contains($segment, '{'),
             )),

--- a/src/Http/Middleware/CheckForRedirects.php
+++ b/src/Http/Middleware/CheckForRedirects.php
@@ -4,6 +4,7 @@ namespace Esign\Redirects\Http\Middleware;
 
 use Closure;
 use Esign\Redirects\Contracts\RedirectorContract;
+use Esign\Redirects\DataTransferObjects\RedirectDTO;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
@@ -32,6 +33,9 @@ class CheckForRedirects
     {
         $redirects = app(RedirectorContract::class)->getRedirectsForRequest($request);
         $router = new Router(app(Dispatcher::class), app(Container::class));
+
+        usort($redirects, fn ($a, $b) => $this->compareRedirects($a, $b));
+
         foreach ($redirects as $redirectDTO) {
             $router->redirect(
                 $redirectDTO->oldUrl,
@@ -41,5 +45,30 @@ class CheckForRedirects
         }
 
         return $router->dispatch($request);
+    }
+
+    protected function compareRedirects(RedirectDTO $a, RedirectDTO $b): int
+    {
+        // Greedy wildcards (constraints containing .*) are the least specific — always last
+        $aGreedy = in_array('.*', $a->constraints) ? 1 : 0;
+        $bGreedy = in_array('.*', $b->constraints) ? 1 : 0;
+
+        if ($aGreedy !== $bGreedy) {
+            return $aGreedy <=> $bGreedy;
+        }
+
+        // Fewer parameters = more specific = first
+        $aParams = substr_count($a->oldUrl, '{');
+        $bParams = substr_count($b->oldUrl, '{');
+
+        if ($aParams !== $bParams) {
+            return $aParams <=> $bParams;
+        }
+
+        // Tie-break: more literal segments = more specific = first
+        $aLiterals = count(array_filter(explode('/', $a->oldUrl), fn ($s) => ! str_contains($s, '{')));
+        $bLiterals = count(array_filter(explode('/', $b->oldUrl), fn ($s) => ! str_contains($s, '{')));
+
+        return $bLiterals <=> $aLiterals;
     }
 }

--- a/tests/RedirectTest.php
+++ b/tests/RedirectTest.php
@@ -2,6 +2,7 @@
 
 namespace Esign\Redirects\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Esign\Redirects\Models\Redirect;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -120,6 +121,136 @@ final class RedirectTest extends TestCase
             ->get('nl/blog/my-blog-post')
             ->assertStatus(Response::HTTP_FOUND)
             ->assertRedirect('nl-be/blog/my-blog-post');
+    }
+
+    public static function redirectInsertionOrderProvider(): array
+    {
+        return [
+            'parametric first, exact second' => [
+                ['old_url' => 'nl/blog/{slug}', 'new_url' => 'nl/new-blog/{slug}'],
+                ['old_url' => 'nl/blog/article-c', 'new_url' => 'nl/new-blog/new-article-c'],
+            ],
+            'exact first, parametric second' => [
+                ['old_url' => 'nl/blog/article-c', 'new_url' => 'nl/new-blog/new-article-c'],
+                ['old_url' => 'nl/blog/{slug}', 'new_url' => 'nl/new-blog/{slug}'],
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('redirectInsertionOrderProvider')]
+    public function it_prioritizes_exact_matches_over_parametric_redirects_regardless_of_database_order(array $first, array $second): void
+    {
+        Redirect::create($first);
+        Redirect::create($second);
+
+        $this->get('nl/blog/article-a')
+            ->assertStatus(Response::HTTP_FOUND)
+            ->assertRedirect('nl/new-blog/article-a');
+
+        $this->get('nl/blog/article-b')
+            ->assertStatus(Response::HTTP_FOUND)
+            ->assertRedirect('nl/new-blog/article-b');
+
+        $this->get('nl/blog/article-c')
+            ->assertStatus(Response::HTTP_FOUND)
+            ->assertRedirect('nl/new-blog/new-article-c');
+    }
+
+    public static function multiParameterInsertionOrderProvider(): array
+    {
+        return [
+            'two-param first, one-param second' => [
+                ['old_url' => 'nl/blog/{category}/{slug}', 'new_url' => 'nl/new-blog/{category}/{slug}'],
+                ['old_url' => 'nl/blog/news/{slug}', 'new_url' => 'nl/news/{slug}'],
+            ],
+            'one-param first, two-param second' => [
+                ['old_url' => 'nl/blog/news/{slug}', 'new_url' => 'nl/news/{slug}'],
+                ['old_url' => 'nl/blog/{category}/{slug}', 'new_url' => 'nl/new-blog/{category}/{slug}'],
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('multiParameterInsertionOrderProvider')]
+    public function it_prioritizes_fewer_parameter_routes_over_more_generic_ones_regardless_of_database_order(array $first, array $second): void
+    {
+        Redirect::create($first);
+        Redirect::create($second);
+
+        // /nl/blog/news/{slug} is more specific and should win for news URLs
+        $this->get('nl/blog/news/article-a')
+            ->assertStatus(Response::HTTP_FOUND)
+            ->assertRedirect('nl/news/article-a');
+
+        // /nl/blog/{category}/{slug} should handle other categories
+        $this->get('nl/blog/sports/article-b')
+            ->assertStatus(Response::HTTP_FOUND)
+            ->assertRedirect('nl/new-blog/sports/article-b');
+    }
+
+    public static function literalSegmentInsertionOrderProvider(): array
+    {
+        return [
+            'generic two-param first, specific two-param second' => [
+                ['old_url' => '{locale}/blog/{slug}', 'new_url' => '{locale}/new-blog/{slug}'],
+                ['old_url' => 'nl/blog/{slug}', 'new_url' => 'nl/new-blog/{slug}'],
+            ],
+            'specific two-param first, generic two-param second' => [
+                ['old_url' => 'nl/blog/{slug}', 'new_url' => 'nl/new-blog/{slug}'],
+                ['old_url' => '{locale}/blog/{slug}', 'new_url' => '{locale}/new-blog/{slug}'],
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('literalSegmentInsertionOrderProvider')]
+    public function it_prioritizes_more_literal_segments_over_more_generic_ones_regardless_of_database_order(array $first, array $second): void
+    {
+        Redirect::create($first);
+        Redirect::create($second);
+
+        // nl/blog/{slug} has more literal segments and should win for nl URLs
+        $this->get('nl/blog/article-a')
+            ->assertStatus(Response::HTTP_FOUND)
+            ->assertRedirect('nl/new-blog/article-a');
+
+        // {locale}/blog/{slug} should handle other locales
+        $this->get('fr/blog/article-a')
+            ->assertStatus(Response::HTTP_FOUND)
+            ->assertRedirect('fr/new-blog/article-a');
+    }
+
+    public static function greedyWildcardInsertionOrderProvider(): array
+    {
+        return [
+            'greedy first, specific second' => [
+                ['old_url' => 'nl/{any?}', 'new_url' => 'nl-be/{any?}', 'constraints' => ['any' => '.*']],
+                ['old_url' => 'nl/blog/{slug}', 'new_url' => 'nl/new-blog/{slug}'],
+            ],
+            'specific first, greedy second' => [
+                ['old_url' => 'nl/blog/{slug}', 'new_url' => 'nl/new-blog/{slug}'],
+                ['old_url' => 'nl/{any?}', 'new_url' => 'nl-be/{any?}', 'constraints' => ['any' => '.*']],
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('greedyWildcardInsertionOrderProvider')]
+    public function it_prioritizes_specific_routes_over_greedy_wildcard_routes_regardless_of_database_order(array $first, array $second): void
+    {
+        Redirect::create($first);
+        Redirect::create($second);
+
+        // nl/blog/{slug} is more specific and should win over the greedy nl/{any?}
+        $this->get('nl/blog/article-a')
+            ->assertStatus(Response::HTTP_FOUND)
+            ->assertRedirect('nl/new-blog/article-a');
+
+        // nl/{any?} should still handle other paths
+        $this->get('nl/contact')
+            ->assertStatus(Response::HTTP_FOUND)
+            ->assertRedirect('nl-be/contact');
     }
 
     #[Test]


### PR DESCRIPTION
## What

Redirects are now matched by specificity rather than database insertion order.

## Why

When a parametric redirect (e.g. `nl/blog/{slug}`) was inserted before an exact redirect (e.g. `nl/blog/article-c`), the parametric route would win — silently producing the wrong destination. This was entirely dependent on DB insertion order, which is fragile.

## How

A `protected compareRedirects()` method is added to `CheckForRedirects` which sorts redirects before registering them with the router:

1. **Exact routes** (no parameters) match first
2. **Fewer parameters** match before more generic ones
3. **More literal segments** take priority when parameter counts are equal
4. **Greedy wildcard routes** (`.*`) match last

The method is `protected` so users can subclass `CheckForRedirects` and override the ordering strategy entirely.

## Breaking change

This is a **major** release. Users relying on DB insertion order to resolve conflicts between overlapping redirects may see different behaviour. See `UPGRADING.md` for details.